### PR TITLE
add CJK font option

### DIFF
--- a/FlexiPlasmidDraw2017.html
+++ b/FlexiPlasmidDraw2017.html
@@ -169,6 +169,7 @@ input[type=text]{
 		<option value="0" selected="selected" style="font-family:Arial, Helvetica, sans-serif">Arial</option>
         <option value="1" style="font-family:'Times New Roman', Times, serif">Times</option>
         <option value="2" style="font-family:'Courier New', Courier, monospace">Courier</option>
+        <option value="3" style="font-family: 'Yu Gothic', YuGothic, Gothic, Meiryo">中日韓用</option>
     </select>
 </td>
 <td><input type="text" value="12" id="txtFontSize"  /></td>

--- a/plasmid.js
+++ b/plasmid.js
@@ -432,7 +432,7 @@ var Tyi=Oy-Ri*Math.cos(Theata);
 var fontw="normal";
 if (SArray[0].txtbold) {fontw="bold";}
 var fontfamily=[];
-fontfamily[0]="Arial";fontfamily[1]="Times";fontfamily[2]="Courier";
+fontfamily[0]="Arial";fontfamily[1]="Times";fontfamily[2]="Courier";fontfamily[3]="Yu Gothic"
 var fontfill=SArray[0].txtcolor;
 
 


### PR DESCRIPTION
the typical Arial/Times/Courier in CJK does not work with italic. This patch adds Yu Gothic font for CJK use.